### PR TITLE
Fixes and interface updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,18 @@
+# Project-specific
+# Ignore output from running examples
+/examples/*.pdf
+/examples/*.pgf
+
+# doctest files
+/*.aux
+/*.fdb_latexmk
+/*.fls
+/*.pdf
+/*.pgf
+/*.tex
+/*.txt
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/examples/barplot.py
+++ b/examples/barplot.py
@@ -22,7 +22,7 @@ from pubplot.document_classes import acm_sigconf
 
 def single_plot():
     style = Document(acm_sigconf)
-    fig, ax = style.figure()
+    fig, ax = style.subfigures()
     ax.bar(range(11), range(11))
     fig.save('single_barplot')
 

--- a/examples/simple_plot.py
+++ b/examples/simple_plot.py
@@ -23,7 +23,7 @@ from pubplot.styles import monochromatic
 
 def single_plot():
     doc = Document(ieee_infocom)
-    fig, ax = doc.figure()
+    fig, ax = doc.subfigures()
     ax.plot(range(11), range(11))
     fig.save('single_plot')
 
@@ -31,10 +31,10 @@ def single_plot():
 def fill_subplot_axes(axes, label=False):
     for i, ax in enumerate(axes):
         if i % 3:
-            for j in xrange(1,5):
-                ax.plot(range(11), [j*i for i in xrange(11)])
+            for j in range(1,5):
+                ax.plot(range(11), [j*i for i in range(11)])
         else:
-            ax.bar(range(11), [i for i in xrange(11)])
+            ax.bar(range(11), [i for i in range(11)])
         if label:
             ax.set_xlabel('lorem')
             ax.set_ylabel('ipsum')

--- a/pubplot/__init__.py
+++ b/pubplot/__init__.py
@@ -17,6 +17,7 @@
 # __init__.py
 
 from pubplot.document import Document
+import pubplot.document_classes
 
 __author__ = 'Hugo Sadok'
 __email__ = 'hugo@sadok.com.br'

--- a/pubplot/document.py
+++ b/pubplot/document.py
@@ -107,6 +107,7 @@ class Document(object):
         self.style = {
             'pgf.texsystem': 'pdflatex',
             'text.usetex': True,
+            'figure.dpi': 600,  # recommended DPI for journal prints
 
             # fonts (empty lists inherit from document)
             'font.family': 'serif',

--- a/pubplot/document.py
+++ b/pubplot/document.py
@@ -147,16 +147,18 @@ class Document(object):
         on enter and reverts the style on exit.
 
         Examples:
-            >>> import pubplot as pplt
-            >>> doc = pplt.Document(pplt.document_classes.ieee_jrnl)
-            >>> with doc.temporary_style({'font.size': 6}):
-                    # All font sizes now 6
-                    fig, ax = doc.subfigures(1, 1)
-                    ax[0].plot([1, 2, 3], [1, 2, 3])
-                    fig.save('test')
+            >>> import pubplot  # doctest: +ELLIPSIS
+            >>> pplt = pubplot.Document(pubplot.document_classes.ieee_jrnl)
+            >>> with pplt.temporary_style({'font.size': 6}):
+            ...     # All font sizes now 6
+            ...     fig, ax = pplt.subfigures()
+            ...     ax.plot([1, 2, 3], [1, 2, 3])
+            ...     fig.save('test')
+            [...]
             >>> # Font sizes now reverted
-            >>> fig, ax = doc.subfigures(1, 1)
+            >>> fig, ax = pplt.subfigures()
             >>> ax.plot([1, 2, 3], [1, 2, 3])
+            [...]
             >>> fig.save('test2')
         """
         class _DocumentStyleSetter:
@@ -233,8 +235,8 @@ class Document(object):
             fig = PubFigure(fig, self.style)
         return fig
 
-    def subfigures(self, nrows, ncols, width=None, height=None, scale=1,
-                   xscale=1, yscale=1):
+    def subfigures(self, nrows=1, ncols=1, width=None, height=None, scale=1,
+                   xscale=1, yscale=1, squeeze=True):
         """Creates a new figure with multiple plots.
 
         Args:
@@ -246,9 +248,13 @@ class Document(object):
             scale: overall figure scale, adjusts both width and height.
             xscale: multiply width by xscale, leaving height intact.
             yscale: multiply height by yscale, leaving width intact.
+            squeeze: If True (default) and nrows == 1 and ncols == 1, return
+                    a single axis object rather than a list of axes.
+
 
         Returns:
-            fig, axes: a Figure and a list of axes.
+            fig, axes: a Figure and a list of axes, or, if squeeze == True,
+                    a Figure and an axis object.
         """
         if height is None:
             # Auto-determine figure height; scale it by the number of subplots
@@ -263,4 +269,8 @@ class Document(object):
             ax = PubAxes(lazy_ax, self.style)
             axes.append(ax)
 
+        if squeeze and len(axes) == 1:
+            # Squeeze - special case for nrows == ncols == 1
+            axes = axes[0]
         return fig, axes
+

--- a/pubplot/document.py
+++ b/pubplot/document.py
@@ -96,6 +96,9 @@ class Document(object):
 
     """
 
+    FONT_OVERRIDES = ['font.size', 'axes.labelsize', 'legend.fontsize',
+            'xtick.labelsize', 'ytick.labelsize']
+
     def __init__(self, document_class, style=None):
         sizes = get_document_sizes(document_class)
         self.__dict__.update(sizes)
@@ -124,6 +127,10 @@ class Document(object):
             ]
         }
         if style is not None:
+            style = style.copy()
+            if 'font.size' in style:
+                for k in self.FONT_OVERRIDES:
+                    style.setdefault(k, style['font.size'])
             self.style.update(style)
 
     def update_style(self, new_style):

--- a/pubplot/document_classes.py
+++ b/pubplot/document_classes.py
@@ -20,37 +20,44 @@ from pylatex import Package, NoEscape
 
 ieee_infocom = {
     'documentclass': 'IEEEtran',
-    'document_options': ['10pt', 'conference', 'letterpaper']
+    'document_options': ['10pt', 'conference', 'letterpaper'],
+    'packages': [Package(NoEscape('times'))],
 }
 
 ieee_conf = {
     'documentclass': 'IEEEtran',
-    'document_options': ['conference']
+    'document_options': ['conference'],
+    'packages': [Package(NoEscape('times'))],
 }
 
 ieee_conf_compsoc = {
     'documentclass': 'IEEEtran',
-    'document_options': ['conference', 'compsoc']
+    'document_options': ['conference', 'compsoc'],
+    'packages': [Package(NoEscape('times'))],
 }
 
 ieee_jrnl = {
     'documentclass': 'IEEEtran',
-    'document_options': ['journal']
+    'document_options': ['journal'],
+    'packages': [Package(NoEscape('times'))],
 }
 
 ieee_jrnl_compsoc = {
     'documentclass': 'IEEEtran',
-    'document_options': ['10pt', 'journal', 'compsoc']
+    'document_options': ['10pt', 'journal', 'compsoc'],
+    'packages': [Package(NoEscape('times'))],
 }
 
 ieee_jrnl_comsoc = {
     'documentclass': 'IEEEtran',
-    'document_options': ['journal', 'comsoc']
+    'document_options': ['journal', 'comsoc'],
+    'packages': [Package(NoEscape('times'))],
 }
 
 ieee_jrnl_transmag = {
     'documentclass': 'IEEEtran',
-    'document_options': ['journal', 'transmag']
+    'document_options': ['journal', 'transmag'],
+    'packages': [Package(NoEscape('times'))],
 }
 
 acm_sigconf = {

--- a/pubplot/figure.py
+++ b/pubplot/figure.py
@@ -43,13 +43,10 @@ class PubFigure(RCParamWrapper):
         super(PubFigure, self).__init__(fig, rc)
         self.fig = fig
 
-    def add_gridspec(self, nrows, ncols, **kwargs):
-        return self.fig.add_gridspec(nrows, ncols, **kwargs)
-
     def add_subplot(self, *args, **kwargs):
         with mpl.rc_context(rc=self.rc.get_rc_to_function('')):
             ax = self.fig.add_subplot(*args, **kwargs)
-            return PubAxes(lambda: ax, self.rc)
+            return PubAxes(ax, self.rc)
 
     def save(self, name, pdf=True, pgf=True):
         """Save figure to pgf and pdf.

--- a/pubplot/figure.py
+++ b/pubplot/figure.py
@@ -21,6 +21,7 @@ import warnings
 import matplotlib as mpl
 from matplotlib.backends.backend_pgf import FigureCanvasPgf
 
+from pubplot.axes import PubAxes
 from pubplot.helpers import RCParamWrapper
 
 
@@ -42,6 +43,14 @@ class PubFigure(RCParamWrapper):
         super(PubFigure, self).__init__(fig, rc)
         self.fig = fig
 
+    def add_gridspec(self, nrows, ncols, **kwargs):
+        return self.fig.add_gridspec(nrows, ncols, **kwargs)
+
+    def add_subplot(self, *args, **kwargs):
+        with mpl.rc_context(rc=self.rc.get_rc_to_function('')):
+            ax = self.fig.add_subplot(*args, **kwargs)
+            return PubAxes(lambda: ax, self.rc)
+
     def save(self, name, pdf=True, pgf=True):
         """Save figure to pgf and pdf.
 
@@ -57,7 +66,8 @@ class PubFigure(RCParamWrapper):
             canvas = FigureCanvasPgf(self.fig)
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
+                kw = {'bbox_inches': 'tight', 'pad_inches': 0}
                 if pgf:
-                    canvas.print_figure(name + '.pgf', bbox_inches='tight')
+                    canvas.print_figure(name + '.pgf', **kw)
                 if pdf:
-                    canvas.print_figure(name + '.pdf', bbox_inches='tight')
+                    canvas.print_figure(name + '.pdf', **kw)

--- a/pubplot/latex.py
+++ b/pubplot/latex.py
@@ -142,14 +142,11 @@ def get_document_sizes(document_class):
     \makeatother
     """
     temp_doc_name = next(tempfile._get_candidate_names())
-    
-    if 'packages' in document_class:
-        packages = document_class['packages']
-        del document_class['packages']
-    else:
-        packages = []
 
-    doc = Document(temp_doc_name, **document_class)
+    document_kwargs = document_class.copy()
+    packages = document_kwargs.pop('packages', [])
+
+    doc = Document(temp_doc_name, **document_kwargs)
     doc.packages = packages
     doc.preamble.append(NoEscape(size_command))
     doc.append(Command('title', 'Title'))


### PR DESCRIPTION
As discussed, here's a pull request composed of:

* document_classes namespace now imported into the `pubplot` object by default (accessible via e.g. `import pubplot; pubplot.document_classes.ieee_jrnl`).
* IEEE documents correctly refer to the `times` package.
* LaTeX packages specified in `Document`'s arguments are now correctly added to the matplotlib preamble.
* Specifying `font.size` in style will by default override other unspecified font sizes.
* `Figure` now supports `add_gridspec` and `add_subplots`; `Document.figure()` by default does not create any axes, which matches matplotlib's behavior.
* `tight_layout` and `canvas.print_figure` parameters have been fixed to ensure correct font sizes are maintained on save.

On a side note, I see why you have `documentclass` and `document_options`... because of PyLatex.  Too bad (inconsistent underscores), but probably best to follow their suit.

Addresses issue #1 